### PR TITLE
[Forwardport] Duplicate Order Confirmation Emails for PayPal Express checkout order

### DIFF
--- a/app/code/Magento/Paypal/Model/Express/Checkout.php
+++ b/app/code/Magento/Paypal/Model/Express/Checkout.php
@@ -809,7 +809,9 @@ class Checkout
             case \Magento\Sales\Model\Order::STATE_PROCESSING:
             case \Magento\Sales\Model\Order::STATE_COMPLETE:
             case \Magento\Sales\Model\Order::STATE_PAYMENT_REVIEW:
-                $this->orderSender->send($order);
+                if (!$order->getEmailSent()) {
+                    $this->orderSender->send($order);
+                }
                 $this->_checkoutSession->start();
                 break;
             default:


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14820
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
Duplicate Order Confirmation Emails PayPal

### Fixed Issues (if relevant)

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Configure payment method PayPal Payments Pro with Express Checkout
2. Set Payment Action = Sale
Basic Settings - PayPal Payments Pro -> Payment Action = Sale
Basic Settings - PayPal Express Checkout -> Payment Action = Sale 
3. Go to frontend, create order with Express Checkout
### Actual result
 Customer gets two Order confirmation emails
### Expected result
Customer should get one Order confirmation email

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
