### PR TITLE
[Forwardport] Add statement to 'beforeSave' method to allow app:config:import

### DIFF
--- a/app/code/Magento/Braintree/Model/Adminhtml/System/Config/CountryCreditCard.php
+++ b/app/code/Magento/Braintree/Model/Adminhtml/System/Config/CountryCreditCard.php
@@ -66,6 +66,13 @@ class CountryCreditCard extends Value
     public function beforeSave()
     {
         $value = $this->getValue();
+        if (!is_array($value)) {
+            try {
+                $value = $this->serializer->unserialize($value);
+            } catch (\InvalidArgumentException $e) {
+                $value = [];
+            }
+        }
         $result = [];
         foreach ($value as $data) {
             if (empty($data['country_id']) || empty($data['cc_types'])) {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14829
<!--- Provide a general summary of the Pull Request in the Title above -->
Fix to app:config:import for beforeSave method on Braintree CountryCreditCard class.

### Description
<!--- Provide a description of the changes proposed in the pull request -->
```bash
magento@04065890c38d:/srv/magento2$ php bin/magento app:config:import
Processing configurations data from configuration file...
Import failed: Warning: Invalid argument supplied for foreach() in /srv/magento2/vendor/magento/module-braintree/Model/Adminhtml/System/Config/CountryCreditCard.php on line 70
```

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. php bin/magento app:config:dump
2. change some configs
3. php bin/magento app:config:import

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
