### PR TITLE
[Forwardport] Changed return type of addToCartPostParams to array

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/ListProduct.php
+++ b/app/code/Magento/Catalog/Block/Product/ListProduct.php
@@ -356,7 +356,7 @@ class ListProduct extends AbstractProduct implements IdentityInterface
      * Get post parameters
      *
      * @param Product $product
-     * @return string
+     * @return array
      */
     public function getAddToCartPostParams(Product $product)
     {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14876
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
\Magento\Catalog\Block\Product\ListProduct::getAddToCartPostParams incorrectly defined a string return type when in fact it's an array

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
