### PR TITLE
[Forwardport] Removed extra spaces from language file

### DIFF
--- a/app/code/Magento/CatalogInventory/i18n/en_US.csv
+++ b/app/code/Magento/CatalogInventory/i18n/en_US.csv
@@ -55,11 +55,7 @@ Inventory,Inventory
 "Only X left Threshold","Only X left Threshold"
 "Display Products Availability in Stock on Storefront","Display Products Availability in Stock on Storefront"
 "Product Stock Options","Product Stock Options"
-"
-                    Please note that these settings apply to individual items in the cart, not to the entire cart.
-                ","
-                    Please note that these settings apply to individual items in the cart, not to the entire cart.
-                "
+"Please note that these settings apply to individual items in the cart, not to the entire cart.","Please note that these settings apply to individual items in the cart, not to the entire cart."
 "Manage Stock","Manage Stock"
 Backorders,Backorders
 "Maximum Qty Allowed in Shopping Cart","Maximum Qty Allowed in Shopping Cart"


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14896
### Description
Removed extra spaces from a key-value in `en_US.csv` file. Because of this extra spaces, it's not translated properly.

### Fixed Issues (if relevant)
1. N/A

### Manual testing scenarios
1. N/A

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
