### PR TITLE
[Forwardport] Fixed Overlay Problems

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less
@@ -528,6 +528,7 @@
 
         .header.links {
             min-width: 175px;
+            z-index: 1000;
         }
 
         &.active {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14963
### Description
If you log in as a Customer, click on mini checkout Icon and then click on Account Menu, mini checkout overlays the Account menu.

![Image of Bug](https://i.imgur.com/mEuR5Ua.png)
